### PR TITLE
enable compiling for non-wasm target

### DIFF
--- a/examples/calculator/contract.rs
+++ b/examples/calculator/contract.rs
@@ -1,6 +1,6 @@
 use crate::error::CalcError;
 use crate::message::CalcMsg;
-use kelk::{context::ContextMut, entry_point, export::Response};
+use kelk::{context::ContextMut, entry_point, Response};
 
 pub fn add(a: i32, b: i32) -> Result<i32, CalcError> {
     Ok(a + b)
@@ -35,5 +35,5 @@ fn process(Context: ContextMut, msg: CalcMsg) -> Result<Response, CalcError> {
         CalcMsg::Div { a, b } => div(a, b),
     }?;
 
-    Ok(Response{res: ans})
+    Ok(Response { res: ans })
 }

--- a/examples/calculator/lib.rs
+++ b/examples/calculator/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod contract;
 mod message;
 mod error;

--- a/kelk/src/export.rs
+++ b/kelk/src/export.rs
@@ -8,15 +8,6 @@
 use crate::context::{ContextExt, ContextMut, OwnedContext};
 use serde::{de::DeserializeOwned, Serialize};
 
-/// TODO
-#[derive(Debug, Serialize)]
-pub struct Response {
-    // TODO: vec<u8> is a bad practice. look for a better response structure
-    // data: Vec<u8>
-    /// TODO
-    pub res: i32
-}
-
 /// do_execute should be wrapped in an external "C" export, containing a contract-specific function as arg
 ///
 /// - `M`: message type for request

--- a/kelk/src/import.rs
+++ b/kelk/src/import.rs
@@ -1,6 +1,15 @@
 use crate::ReturnCode;
 
 
+/// The raw return code returned by the host side.
+#[derive(Debug)]
+#[repr(u32)]
+pub enum ReturnCode {
+    /// The result has no error
+    Success = 0,
+}
+
+
 #[link(wasm_import_module = "zarb")]
 extern "C" {
     fn write_storage(offset: u32, ptr: u32, len: u32) -> ReturnCode;

--- a/kelk/src/kelk.rs
+++ b/kelk/src/kelk.rs
@@ -1,0 +1,12 @@
+//! Kelk TODO
+
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Serialize)]
+pub struct Response {
+    // TODO: vec<u8> is a bad practice. look for a better response structure
+    // data: Vec<u8>
+    /// TODO
+    pub res: i32,
+}

--- a/kelk/src/lib.rs
+++ b/kelk/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod context;
 pub mod error;
+pub mod kelk;
 
 #[cfg(target_arch = "wasm32")]
 mod import;
@@ -34,12 +35,5 @@ pub mod export;
 #[cfg(target_arch = "wasm32")]
 pub use crate::export::do_process;
 
-/// The raw return code returned by the host side.
-#[derive(Debug)]
-#[repr(u32)]
-pub enum ReturnCode {
-    /// The result has no error
-    Success = 0,
-}
-
 pub use kelk_derive::entry_point;
+pub use kelk::Response;


### PR DESCRIPTION
- Enable compiling contract for no-std target (non-wasm)
